### PR TITLE
- do not fail over new DefaultLayout element

### DIFF
--- a/brp-desktop.data/xdg_menu
+++ b/brp-desktop.data/xdg_menu
@@ -945,6 +945,11 @@ sub interpret_menu ($;$$)
 			interpret_Exclude($tree->[$i], $menu{'entries'}, $pool);
 			$i++;
 		}
+                elsif ($tree->[$i] eq 'DefaultLayout') {
+                        $i++;
+			# just ignore, not important for this test
+                        $i++;
+                }
 		elsif ($tree->[$i] eq '0') {
 			$i++;
 			if ($tree->[$i] !~ /^\s*$/) {


### PR DESCRIPTION
Regression in desktop category checking, errors can be seen in hardware:RC-Model/apm_planner factory build for example