### PR TITLE
Added a link to the openSUSE packaging desktop menu categories

### DIFF
--- a/brp-desktop.data/xdg_menu
+++ b/brp-desktop.data/xdg_menu
@@ -1852,6 +1852,7 @@ sub output_validate ($;$)
 			}
 			if ( $menu->{Name} eq 'Applications' or $menu->{Name} eq 'More Programs' ) {
 				$output .= "ERROR: No sufficient Category definition: $desktop->{file} \n";
+				$output .= "Please refer to https://en.opensuse.org/openSUSE:Packaging_desktop_menu_categories";
 				$validate_error = 1;
 			}
 


### PR DESCRIPTION
This is the most common and most annoying error that cancels the build. The documentation at https://en.opensuse.org/openSUSE:Packaging_desktop_menu_categories is good, but hard to find as MediaWiki doesn't search the `openSUSE` namespace by default and all the names in the title are super generic so it can also be hard to google.