### PR TITLE
Add missing newline to Category error message

### DIFF
--- a/brp-desktop.data/xdg_menu
+++ b/brp-desktop.data/xdg_menu
@@ -1852,7 +1852,7 @@ sub output_validate ($;$)
 			}
 			if ( $menu->{Name} eq 'Applications' or $menu->{Name} eq 'More Programs' ) {
 				$output .= "ERROR: No sufficient Category definition: $desktop->{file} \n";
-				$output .= "Please refer to https://en.opensuse.org/openSUSE:Packaging_desktop_menu_categories";
+				$output .= "Please refer to https://en.opensuse.org/openSUSE:Packaging_desktop_menu_categories\n";
 				$validate_error = 1;
 			}
 


### PR DESCRIPTION
Fixes bb0a7d0 ("Hint to the desktop category rules. (#6)")

Signed-off-by: Olaf Hering <olaf@aepfle.de>