### PR TITLE
brp-25-symlink: do not relink /etc/os-release

### DIFF
--- a/brp-25-symlink
+++ b/brp-25-symlink
@@ -143,6 +143,8 @@ do
 	     continue;;
 	/sbin/init,*) # don't create absolute symlink for /sbin/init
 	     continue;;
+	/etc/os-release,*) # don't create absolute symlink for /etc/os-release (boo#1028408).
+	     continue;;
         *,/etc/alternatives/*) # white list alternatives
              ;;
 	*share/automake-*)


### PR DESCRIPTION
Mounting a disk and inspecting "/etc/os-release" should give the information
of the mounted volume, not of the host drive.

https://bugzilla.opensuse.org/show_bug.cgi?id=1028408