### PR TITLE
Strip LTO bytecode from static libraries.

### DIFF
--- a/brp-15-strip-debug
+++ b/brp-15-strip-debug
@@ -37,7 +37,7 @@ while read f; do
 	case $(file "$f") in
 	    *"current ar"*|*ELF*", not stripped"*)
 		chmod u+w "$f" || :
-		strip -p --discard-locals -R .comment -R .note "$f" || :
+		strip -p --discard-locals -R .comment -R .note -R .gnu.lto_* "$f" || :
 		;;
 	    *)
 		echo "WARNING: Strange looking archive $(file $f)"


### PR DESCRIPTION
In order to not deliver a static library with a LTO bytecode, we should strip it.
Note that rpmlint can detect such ELF files. Having that, one can use `-ffat-lto-objects` option to both utilize LTO and deliver normal static libs as well.