### PR TITLE
add Teaching and X-KDE-Teaching to Education

### DIFF
--- a/brp-desktop.data/applications.menu
+++ b/brp-desktop.data/applications.menu
@@ -835,6 +835,17 @@
 				</And>
 			</Include>
 		</Menu>
+		<Menu>
+			<Name>Teaching</Name>
+			<Directory>suse-education-teaching.directory</Directory>
+			<Include>
+				<And>
+					<Category>Education</Category>
+					<Category>Teaching</Category>
+					<Category>X-KDE-Edu-Teaching</Category>
+				</And>
+			</Include>
+		</Menu>
 	</Menu>
 	<Menu>
 		<Name>Games</Name>

--- a/brp-desktop.data/applications.menu
+++ b/brp-desktop.data/applications.menu
@@ -841,8 +841,10 @@
 			<Include>
 				<And>
 					<Category>Education</Category>
-					<Category>Teaching</Category>
-					<Category>X-KDE-Edu-Teaching</Category>
+					<Or>
+						<Category>Teaching</Category>
+						<Category>X-KDE-Edu-Teaching</Category>
+					</Or>
 				</And>
 			</Include>
 		</Menu>


### PR DESCRIPTION
Add the subcategories X-KDE-Edu-Teaching and Teaching (not in upstream spec yet) to the Education menu as specified in https://en.opensuse.org/openSUSE:Packaging_desktop_menu_categories.

Missing X-KDE-Edu-Teaching breaks some KDE packages according to a comment in #18 and #26 