### PR TITLE
Also strip lto data from .o files (boo#1146634)

### DIFF
--- a/brp-15-strip-debug
+++ b/brp-15-strip-debug
@@ -44,4 +44,4 @@ while read f; do
 		continue
 		;;
 	esac
-done < <(find "$RPM_BUILD_ROOT" "${FIND_IGNORE[@]}" -type f -name "*.a" -print)
+done < <(find "$RPM_BUILD_ROOT" "${FIND_IGNORE[@]}" -type f -name "*.[ao]" -print)


### PR DESCRIPTION
Also strip lto data from `.o` files
to make build of our `pcc` package reproducible.

https://bugzilla.opensuse.org/show_bug.cgi?id=1146634