### PR TITLE
refactor brp-15-strip-debug to not use /dev/fd/62

### DIFF
--- a/brp-15-strip-debug
+++ b/brp-15-strip-debug
@@ -19,21 +19,19 @@ FIND_IGNORE=(
 )
 
 # Strip debuginfo from ELF binaries, but not static libraries or kernel modules
-while read f; do
+find "$RPM_BUILD_ROOT" "${FIND_IGNORE[@]}" \( -name "*.a" -o -name "*.ko" \) \
+   -prune -o \
+   -type f \( -perm /0111 -o -name "*.so*" \) \
+   -exec file {} + | \
+sed -n -e 's/^\(.*\):[ ]*ELF.*, not stripped.*$/\1/p' |  while read f; do
 	mode="$(stat -c %a "$f")"
 	chmod u+w "$f" || :
 	strip -p --strip-debug --discard-locals -R .comment -R .note "$f" || :
 	chmod "$mode" "$f"
-done < <(
-    find "$RPM_BUILD_ROOT" "${FIND_IGNORE[@]}" \( -name "*.a" -o -name "*.ko" \) \
-	-prune -o \
-	-type f \( -perm /0111 -o -name "*.so*" \) \
-	-exec file {} + | \
-    sed -n -e 's/^\(.*\):[ ]*ELF.*, not stripped.*$/\1/p'
-)
+done
 
 # Don't strip debuginfo from static libs, but compiler-generated local symbols
-while read f; do
+find "$RPM_BUILD_ROOT" "${FIND_IGNORE[@]}" -type f -name "*.a" -print | while read f; do
 	case $(file "$f") in
 	    *"current ar"*|*ELF*", not stripped"*)
 		chmod u+w "$f" || :
@@ -44,4 +42,4 @@ while read f; do
 		continue
 		;;
 	esac
-done < <(find "$RPM_BUILD_ROOT" "${FIND_IGNORE[@]}" -type f -name "*.a" -print)
+done


### PR DESCRIPTION
otherwise it fails with message 
```
calling /usr/lib/rpm/brp-suse.d/brp-15-strip-debug
/usr/lib/rpm/brp-suse.d/brp-15-strip-debug: line 33: /dev/fd/62: No such file or directory
/usr/lib/rpm/brp-suse.d/brp-15-strip-debug: line 47: /dev/fd/62: No such file or directory
error: Bad exit status from /var/tmp/rpm-tmp.1LutDl (%install)
```