### PR TITLE
Make links *to* /etc/aternatives absolute links

### DIFF
--- a/brp-25-symlink
+++ b/brp-25-symlink
@@ -36,7 +36,8 @@ do
     fi
 
     case "$link,$link_absolut" in
-        *,/etc/alternatives/*) # white list alternatives
+        *,/etc/alternatives/*) # update alternative links are special
+            link_dest=$link_absolut
             ;;
         *,*share/automake-*)
             echo "ERROR: link target $link points into automake directory"


### PR DESCRIPTION
update-alternatives expects (and writes) absolute symlinks, so relinking
those causes harm when updating the package. See https://bugzilla.opensuse.org/1172896