### PR TITLE
skip . in links

### DIFF
--- a/prg-brp-symlink/main.cpp
+++ b/prg-brp-symlink/main.cpp
@@ -40,7 +40,7 @@ vector<string> split_paths(string path)
         token = path.substr(0, pos);
         if (token == "..") {
             paths.pop_back();
-        } else {
+        } else if (token != ".") {
             paths.push_back(token);
         }
         path.erase(0, pos + 1);

--- a/prg-brp-symlink/tests.in
+++ b/prg-brp-symlink/tests.in
@@ -1373,3 +1373,4 @@ bin/vi|/usr/bin/vim
 bin/vim|/usr/bin/vim
 bin/ex|/usr/bin/vim
 bin/keyctl|//usr/bin/keyctl
+a/b/c/d/link|.././../O

--- a/prg-brp-symlink/tests.out
+++ b/prg-brp-symlink/tests.out
@@ -1373,3 +1373,4 @@
 /bin/vim|/usr/bin/vim|../usr/bin/vim|/usr/bin/vim
 /bin/ex|/usr/bin/vim|../usr/bin/vim|/usr/bin/vim
 /bin/keyctl|//usr/bin/keyctl|../usr/bin/keyctl|/usr/bin/keyctl
+/a/b/c/d/link|.././../O|../../O|/a/b/O


### PR DESCRIPTION
Just skip . and do not add it to paths. It wouldn't work for pop_back
later.

Add a testcase for this too.

bsc#1179082