### PR TITLE
Makefile: enable `-O2` and use standard variables

### DIFF
--- a/prg-brp-symlink/Makefile
+++ b/prg-brp-symlink/Makefile
@@ -1,7 +1,10 @@
+CXXFLAGS=-O2 -Wall
+CXX=g++
+
 all: brp-symlink
 
 brp-symlink: main.cpp
-	g++ -I. -std=c++17 main.cpp -o brp-symlink
+	$(CXX) $(CXXFLAGS) -o $@ $^
 
 check: brp-symlink
 	./brp-symlink < tests.in > tests.new


### PR DESCRIPTION
Use `CXXFLAGS` and `CXX` and enable `-O2`. `-I.` is no longer needed.

`-O2` improves the times by ~ 45 % here -- on 100 times of `tests.in` it
goes from 1800 to 1000 ms.