### PR TITLE
Detect if a link points inside the build root

### DIFF
--- a/brp-25-symlink
+++ b/brp-25-symlink
@@ -40,19 +40,24 @@ do
         /etc/alternatives/*) # update alternative links are special
             link_dest=$link_absolut
             ;;
-        *share/automake-*)
-            echo "ERROR: link target $link points into automake directory"
-            echo " You might want to add a -c to the automake call (or just"
-            echo " skip the files from packaging)"
-            had_errors=1
-            continue
-            ;;
         /opt/kde3/share/doc*/HTML/*/common) # white listed for not existant
             ;;
         /usr/share/doc/kde/HTML/*/common) # white listed for not existant
             ;;
         /proc/*|/dev/*|/sys/*) # links pointing into kernel file system should be absolute
             link_dest=$link_absolut
+            ;;
+        ${RPM_BUILD_ROOT}*)
+            echo "ERROR: Link $link -> $link_orig points inside build root!"
+            had_errors=1
+            continue
+            ;;
+        *share/automake-*)
+            echo "ERROR: link target $link points into automake directory"
+            echo " You might want to add a -c to the automake call (or just"
+            echo " skip the files from packaging)"
+            had_errors=1
+            continue
             ;;
         *)
             if test ! -L ./"$link_absolut" && test ! -e "$link_absolut" && test ! -e ./"$link_absolut"; then

--- a/brp-25-symlink
+++ b/brp-25-symlink
@@ -36,22 +36,22 @@ do
         continue
     fi
 
-    case "$link,$link_absolut" in
-        *,/etc/alternatives/*) # update alternative links are special
+    case "$link_absolut" in
+        /etc/alternatives/*) # update alternative links are special
             link_dest=$link_absolut
             ;;
-        *,*share/automake-*)
+        *share/automake-*)
             echo "ERROR: link target $link points into automake directory"
             echo " You might want to add a -c to the automake call (or just"
             echo " skip the files from packaging)"
             had_errors=1
             continue
             ;;
-        *,/opt/kde3/share/doc*/HTML/*/common) # white listed for not existant
+        /opt/kde3/share/doc*/HTML/*/common) # white listed for not existant
             ;;
-        *,/usr/share/doc/kde/HTML/*/common) # white listed for not existant
+        /usr/share/doc/kde/HTML/*/common) # white listed for not existant
             ;;
-        *,/proc/*|*,/dev/*|*,/sys/*) # links pointing into kernel file system should be absolute
+        /proc/*|/dev/*|/sys/*) # links pointing into kernel file system should be absolute
             link_dest=$link_absolut
             ;;
         *)

--- a/brp-25-symlink
+++ b/brp-25-symlink
@@ -32,7 +32,8 @@ while IFS="|" read link link_orig link_dest link_absolut
 do
     if test "$link" = "$link_dest"; then
         echo "ERROR: $link points to itself (as $orig_link_dest)"
-        exit 1
+        had_errors=1
+        continue
     fi
 
     case "$link,$link_absolut" in
@@ -43,7 +44,8 @@ do
             echo "ERROR: link target $link points into automake directory"
             echo " You might want to add a -c to the automake call (or just"
             echo " skip the files from packaging)"
-            exit 1
+            had_errors=1
+            continue
             ;;
         *,/opt/kde3/share/doc*/HTML/*/common) # white listed for not existant
             ;;
@@ -57,7 +59,10 @@ do
                 echo "ERROR: link target doesn't exist (neither in build root nor in installed system):"
                 echo "  $link -> $link_orig"
                 echo "Add the package providing the target to BuildRequires and Requires"
-                test "$NO_BRP_STALE_LINK_ERROR" != "yes" && had_errors=1
+                if [ "$NO_BRP_STALE_LINK_ERROR" != "yes" ]; then
+                    had_errors=1
+                    continue
+                fi
             fi
             ;;
     esac


### PR DESCRIPTION
Previously, RPM took care of checking that, but it only does that for symlinks
with an absolute target path. This script blindly converts them to relative
paths though, so add a check here.

Also contains a commit to print all errors in one run, instead of exiting prematurely.