### PR TITLE
Let symlinks from /lib/modules to /usr/src be absolute

### DIFF
--- a/brp-25-symlink
+++ b/brp-25-symlink
@@ -85,6 +85,9 @@ do
         /proc/*|/dev/*|/sys/*) # links pointing into kernel file system should be absolute
             link_dest=$link_absolut
             ;;
+        /usr/src/linux*) # bsc#1186710 - usrmerge in combination of fixed /lib/modules
+            link_dest=$link_absolut
+            ;;
         ${RPM_BUILD_ROOT}*)
             echo "ERROR: Link $link -> $link_orig points inside build root!"
             had_errors=1


### PR DESCRIPTION
Full story at https://bugzilla.opensuse.org/show_bug.cgi?id=1186710