### PR TITLE
Fix /etc/alternatives being white listed

### DIFF
--- a/brp-25-symlink
+++ b/brp-25-symlink
@@ -41,6 +41,8 @@ do
             ;;
         /usr/share/doc/kde/HTML/*/common) # white listed for not existant
             ;;
+        /etc/alternatives/*) # white listed (ghosts)
+            ;;
         ${RPM_BUILD_ROOT}*)
             echo "ERROR: Link $link -> $link_orig points inside build root!"
             had_errors=1


### PR DESCRIPTION
783988906f1362e9a48e2bbbf41a880c97396ff3 had an unexpected side effect.
/etc/alternatives is not only mapped to be an absolute link, it's also
white listed for non-existant as it skips the case

So adding the white list back for it