### PR TITLE
Revert "Let symlinks from /lib/modules to /usr/src be absolute"

### DIFF
--- a/prg-brp-symlink/main.cpp
+++ b/prg-brp-symlink/main.cpp
@@ -100,10 +100,6 @@ string check_exceptions(const string& link_relative, const string& link_absolute
     if (!link_absolute.rfind("/etc/alternatives/", 0)) {
         return link_absolute;
     }
-    // bsc#1186710 - usrmerge in combination of hardcoded /lib/modules
-    if (!link_absolute.rfind("/usr/src/linux", 0)) {
-        return link_absolute;
-    }
     // links pointing into kernel file system should be absolute
     if (!link_absolute.rfind("/proc/", 0) || !link_absolute.rfind("/dev/", 0) || !link_absolute.rfind("/sys/", 0)) {
         return link_absolute;


### PR DESCRIPTION
See boo#1190528; the change to absolute symlinks breaks `find-provides.ksyms`.
Because the kernel is usrmerged now, the relative links will be correct again.

Reverts: 823d04c ("Let symlinks from /lib/modules to /usr/src be absolute")

~don't merge yet - testing in IBS (home:mwilck:usrmerge)~

Meanwhile I've tested this, and it actually fixes the issue.