### PR TITLE
Remove __patchable_function_entries from .a objects

### DIFF
--- a/brp-15-strip-debug
+++ b/brp-15-strip-debug
@@ -35,7 +35,7 @@ find "$RPM_BUILD_ROOT" "${FIND_IGNORE[@]}" -type f -name "*.[ao]" -print | while
 	case $(file "$f") in
 	    *"current ar"*|*ELF*", not stripped"*)
 		chmod u+w "$f" || :
-		${CROSS_COMPILE}strip -p --discard-locals -R .comment -R .note -R .gnu.lto_* -R .gnu.debuglto_* -N __gnu_lto_v1 "$f" || :
+		${CROSS_COMPILE}strip -p --discard-locals -R .comment -R .note -R .gnu.lto_* -R .gnu.debuglto_* -R __patchable_function_entries -N __gnu_lto_v1 "$f" || :
 		;;
 	    *)
 		echo "WARNING: Strange looking archive $(file $f)"


### PR DESCRIPTION
We do not want to have livepatchable sections on static libraries shipped in SLE, as it can be a source of problems (bsc#1208721).

As suggested by @marxin .