### PR TITLE
prg-brp-symlink: Check against end of vector before dereference it2

### DIFF
--- a/prg-brp-symlink/main.cpp
+++ b/prg-brp-symlink/main.cpp
@@ -80,7 +80,7 @@ string relative(const string& p1, const string& p2)
     vector<string>::const_iterator it1 = paths1.begin();
     vector<string>::const_iterator it2 = paths2.begin();
     // first remove the common parts
-    while (it1 != paths1.end() && *it1 == *it2) {
+    while (it1 != paths1.end() && it2 != paths2.end() && *it1 == *it2) {
         it1++;
         it2++;
     }

--- a/prg-brp-symlink/tests.in
+++ b/prg-brp-symlink/tests.in
@@ -1378,3 +1378,4 @@ etc/alternatives/subdir|/usr/lib64/libsub
 usr/lib64/libfoo.so|subdir/libfoo.so
 usr/lib64/libsub/libfoo.so|libfoo.so.0
 usr/lib64/subdir|/etc/alternatives/subdir
+usr/lib/systemd/tests/integration-tests/standalone/integration-tests|..

--- a/prg-brp-symlink/tests.out
+++ b/prg-brp-symlink/tests.out
@@ -1378,3 +1378,4 @@
 /usr/lib64/libfoo.so|subdir/libfoo.so|subdir/libfoo.so|/etc/alternatives/subdir/libfoo.so
 /usr/lib64/libsub/libfoo.so|libfoo.so.0|libfoo.so.0|/usr/lib64/libsub/libfoo.so.0
 /usr/lib64/subdir|/etc/alternatives/subdir|/etc/alternatives/subdir|/etc/alternatives/subdir
+/usr/lib/systemd/tests/integration-tests/standalone/integration-tests|..|..|/usr/lib/systemd/tests/integration-tests


### PR DESCRIPTION
Fix https://bugzilla.opensuse.org/show_bug.cgi?id=1259443