### PR TITLE
Avoid process substitution in BRP scripts

### DIFF
--- a/brp-25-symlink
+++ b/brp-25-symlink
@@ -27,6 +27,9 @@ LC_TIME=POSIX
 cd $RPM_BUILD_ROOT
 
 had_errors=0
+tmpfile=$(mktemp) || exit 1
+trap 'rm -f "$tmpfile"' EXIT
+find . -type l -printf '%P|%l\n' | sort | brp-symlink.prg > "$tmpfile" || exit 1
 
 while IFS="|" read link link_orig link_dest link_absolut
 do
@@ -74,7 +77,7 @@ do
         # and then semantic changes
         rm ./"$link" && ln -s -- "$link_dest" ./"$link"
     fi
-done < <(find . -type l -printf '%P|%l\n' | sort | brp-symlink.prg)
+done < "$tmpfile"
 
 if test "$had_errors" = 1; then
     exit 1

--- a/brp-75-ar
+++ b/brp-75-ar
@@ -13,6 +13,6 @@ if [ "$NO_BRP_AR" = "true" ] ; then
 	exit 0
 fi
 
-while read f; do
+find "$RPM_BUILD_ROOT" -type f -name "*.a" -print0 | while IFS= read -r -d '' f; do
 	! file "$f" | grep -q "ar archive" || ${CROSS_COMPILE}objcopy -D "$f" || true
-done < <(find "$RPM_BUILD_ROOT" -type f -name "*.a" -print)
+done


### PR DESCRIPTION
Bash process substitution requires a working /dev/fd, which may be missing in nested chroot/container builds. Use regular pipeline/tempfile input instead so the BRP checks remain usable in restricted build roots.

Fixes: https://github.com/openSUSE/brp-check-suse/issues/54